### PR TITLE
Fix of Docker setup for frotnend

### DIFF
--- a/docker-compose.dev.yaml
+++ b/docker-compose.dev.yaml
@@ -10,7 +10,7 @@ services:
       - "3000:3000"
       - "3001:80"
     environment:
-      - MY_REACT_APP_API_URL=http://localhost:5000/api/v1
+      - MY_REACT_APP_BACKEND_URL=http://localhost:5000/api/v1
     networks:
       - feelgpt-network
   backend:

--- a/frontend/.gitattributes
+++ b/frontend/.gitattributes
@@ -1,0 +1,2 @@
+# Nesesary for Docker use
+**/*.sh text eol=lf

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -18,6 +18,8 @@ COPY ./nginx/nginx.conf /etc/nginx/conf.d/default.conf
 # Copy the build output to the Nginx
 COPY --from=build /app/build /usr/share/nginx/html
 
+RUN chmod +x /usr/local/bin/entrypoint.sh
+
 EXPOSE 80
 
 ENTRYPOINT [ "/usr/local/bin/entrypoint.sh" ]


### PR DESCRIPTION
Fixed docker compose setup for the frontend container. Problem was in line ending in entrypoint.sh, which needs to have line ending in LF style, but it was in CTLF. That caused to container to not be able to start. 