### PR TITLE
add weight to neutral 0.5

### DIFF
--- a/frontend/src/components/Chat.js
+++ b/frontend/src/components/Chat.js
@@ -272,6 +272,9 @@ const Chat = ({
         // Extract age, gender, and emotions
         const { age, gender, ...emotions } = emotionValues;
   
+        // Adding weight
+        emotionValues.neutral = emotionValues.neutral * 0.5;
+
         // Determine the dominant emotion
         let maxEmotion = null;
         let maxEmotionValue = -Infinity;
@@ -404,7 +407,7 @@ const Chat = ({
               <input
                 type="range"
                 className="win10-thumb"
-                value={emotionValues.neutral * 100}
+                value={emotionValues.neutral * 100 * 0.5}
                 onChange={(e) =>
                   setEmotionValues((prev) => ({
                     ...prev,


### PR DESCRIPTION
added weight to neutral so that it appeares less in the emotion labels and to catch more micro expressions -> emotion label still show the last emotion, and not the most common so keep that in mind (this update is in the branch chat design updates)